### PR TITLE
Add error raise when duplicated timestamps are present.

### DIFF
--- a/spec/features/sql_scripts_spec.rb
+++ b/spec/features/sql_scripts_spec.rb
@@ -43,5 +43,13 @@ describe 'sql scripts' do
              "Migration second_db_test_migration for `test2_db` database, datetime: 20150511144000\n"
             ).to_stdout
   end
+
+  it 'should raise an error if two files of same type with same timestamp are present' do
+    File.open('/migrations/default/20150511_144100_duplicated_timestamp_migration.sql', 'w') do |f|
+      f.puts 'CREATE TABLE duplicated_migration(col_int1 INTEGER)'
+    end
+
+    expect { SqlMigrations.list_files }.to raise_error(RuntimeError, /Duplicate timestamps for migrations: .*/)
+  end
 end
 # rubocop:enable Metrics/LineLength


### PR DESCRIPTION
When are present two files of one type (migration, feature, seed) with the same
timestamp, then only the first is executed. And there is no warning. But when you
try to generate a list of sql scripts for this type all will be listed.

I've added a method for finding duplicates and error raise to 'SqlScript::find'
method. If you will add two files of one type with the same timestamp, then while
executing or while listing files for this type there will be raised an error.
